### PR TITLE
Enable Comments and Improve Media Handling

### DIFF
--- a/core/src/access/migrations/20191013211321_init.ts
+++ b/core/src/access/migrations/20191013211321_init.ts
@@ -280,10 +280,41 @@ export async function up(knex: Knex): Promise<any> {
 				.onDelete("CASCADE")
 				.onUpdate("CASCADE");
         })
+        .createTable("comments", table => {
+            table.uuid("id").primary();
+
+            table.string("body", constants.MEDIUM);
+
+            table
+                .dateTime("createdAt")
+                .notNullable()
+                .defaultTo(knex.fn.now());
+
+            // references
+            table
+				.uuid("projectId")
+				.notNullable()
+				.references("id")
+				.inTable("projects")
+                .onDelete("CASCADE");
+
+			table
+				.string("userId", constants.SMALL)
+				.references("id")
+				.inTable("users")
+                .onDelete("CASCADE");
+                
+            table
+                .uuid("parentId")
+                .references("id")
+                .inTable("comments")
+                .onDelete("CASCADE");
+        })
 }
 
 export async function down(knex: Knex): Promise<any> {
     return knex.schema
+        .dropTableIfExists("comments")
         .dropTableIfExists("invites")
         .dropTableIfExists("rolesValues")
         .dropTableIfExists("notifications")

--- a/core/src/access/models/CommentModel.ts
+++ b/core/src/access/models/CommentModel.ts
@@ -1,0 +1,14 @@
+import { Model } from "objection";
+import { join } from "path";
+import { CommentMaster } from "../../schemas/types/Comment/CommentMaster";
+
+export default class CommentModel extends Model implements CommentMaster {
+    static tableName = "comments";
+
+    id!: string;
+    projectId!: string;
+    parentId!: string;
+    userId!: string;
+    body!: string;
+    createdAt!: Date;
+}

--- a/core/src/access/queries/CreateCommentQuery.ts
+++ b/core/src/access/queries/CreateCommentQuery.ts
@@ -1,0 +1,31 @@
+import { CommentMaster } from "../../schemas/types/Comment/CommentMaster"
+import CommentModel from "../models/CommentModel"
+import { CommentImmutable } from "../../schemas/types/Comment/CommentImmutable"
+
+namespace CreateCommentQuery {
+
+    export type Params = {
+        projectId: string;
+        parentId?: string;
+        userId: string;
+    } & CommentImmutable;
+
+    export type Result = CommentMaster;
+}
+
+export class CreateCommentQuery {
+
+    public async execute(params: CreateCommentQuery.Params): Promise<CreateCommentQuery.Result> {
+        try {
+            await CommentModel.query()
+                .insert(params)
+        } catch (e) {
+            console.warn(e);
+        } finally {
+            return CommentModel.query()
+                .findById(params.id)
+                .throwIfNotFound()
+                .then((instance) => instance.$toJson() as CommentMaster);
+        }
+    }
+}

--- a/core/src/app.ts
+++ b/core/src/app.ts
@@ -26,6 +26,7 @@ import { GetProjectMembersQuery } from "./access/queries/GetProjectMembersQuery"
 import { InviteProjectMemberQuery } from "./access/queries/InviteProjectMemberQuery";
 import { InviteReplyQuery } from "./access/queries/InviteReplyQuery";
 import { GetUserNotificationsQuery } from "./access/queries/GetUserNotificationsQuery";
+import { CreateCommentQuery } from "./access/queries/CreateCommentQuery.js";
 
 // controller layer
 import ProjectController from "./controllers/impl/ProjectController";
@@ -35,6 +36,7 @@ import RootController from "./controllers/impl/RootController";
 import UserController from "./controllers/impl/UserController";
 import InviteController from "./controllers/impl/InviteController";
 import ProjectBoardController from "./controllers/impl/ProjectBoardController";
+import CommentController from "./controllers/impl/CommentController.js";
 import { MediaRequestFactory } from "./controllers/mediaRequestFactory";
 
 // service layer
@@ -44,6 +46,7 @@ import InviteService from "./service/InviteService";
 import RootService from "./service/RootService";
 import UserService from "./service/UserService";
 import ProjectBoardService from "./service/ProjectBoardService";
+import CommentService from "./service/CommentService.js";
 
 // core
 import { Server } from "@overnightjs/core";
@@ -116,6 +119,11 @@ class App extends Server {
         new DeleteBoardEntryQuery()
     )
 
+    static commentService = new CommentService(
+        App.emitter,
+        new CreateCommentQuery()
+    )
+
     static requestFactory = new MediaRequestFactory(new AWS.S3());
 
     static eventHandler = new EventHandler(
@@ -185,6 +193,7 @@ class App extends Server {
         controllers.push(new InviteController(App.inviteService));
         controllers.push(new ApplicationController(App.applicationService));
         controllers.push(new ProjectBoardController(App.boardService));
+        controllers.push(new CommentController(App.commentService));
 
 		super.addControllers(controllers);
 	}

--- a/core/src/controllers/extractors.ts
+++ b/core/src/controllers/extractors.ts
@@ -8,6 +8,7 @@ import BoardEntryMutableValidator from '../schemas/build/ProjectBoard/BoardEntry
 import QueryParamsValidator from '../schemas/build/QueryParams/QueryParams/validator';
 import ResponseValidator from '../schemas/build/Response/Response/validator';
 import UserMutableValidator from '../schemas/build/User/UserMutable/validator';
+import CommentImmutableValidator from '../schemas/build/Comment/CommentImmutable/validator';
 import { ApplicationImmutable } from "../schemas/types/Application/ApplicationImmutable";
 import { InviteImmutable } from "../schemas/types/Invite/InviteImmutable";
 import { ProjectImmutable } from "../schemas/types/Project/ProjectImmutable";
@@ -17,6 +18,7 @@ import { BoardEntryMutable } from "../schemas/types/ProjectBoard/BoardEntryMutab
 import { QueryParams } from "../schemas/types/QueryParams/QueryParams";
 import { Response } from "../schemas/types/Response/Response";
 import { UserMutable } from "../schemas/types/User/UserMutable";
+import { CommentImmutable } from "../schemas/types/Comment/CommentImmutable";
 
 
 type Key = string | number;
@@ -62,5 +64,9 @@ export const extractors: Record<string, Extractor> = {
     'UserMutable': {
         validator: UserMutableValidator,
         extract: keys<UserMutable>()
+    },
+    'CommentImmutable': {
+        validator: CommentImmutableValidator,
+        extract: keys<CommentImmutable>()
     }
 }

--- a/core/src/controllers/extractors.ts
+++ b/core/src/controllers/extractors.ts
@@ -9,6 +9,8 @@ import QueryParamsValidator from '../schemas/build/QueryParams/QueryParams/valid
 import ResponseValidator from '../schemas/build/Response/Response/validator';
 import UserMutableValidator from '../schemas/build/User/UserMutable/validator';
 import CommentImmutableValidator from '../schemas/build/Comment/CommentImmutable/validator';
+import ImageMediaImmutableValidator from '../schemas/build/Media/ImageMediaImmutable/validator';
+import BoardMediaImmutableValidator from '../schemas/build/Media/BoardMediaImmutable/validator';
 import { ApplicationImmutable } from "../schemas/types/Application/ApplicationImmutable";
 import { InviteImmutable } from "../schemas/types/Invite/InviteImmutable";
 import { ProjectImmutable } from "../schemas/types/Project/ProjectImmutable";
@@ -19,6 +21,8 @@ import { QueryParams } from "../schemas/types/QueryParams/QueryParams";
 import { Response } from "../schemas/types/Response/Response";
 import { UserMutable } from "../schemas/types/User/UserMutable";
 import { CommentImmutable } from "../schemas/types/Comment/CommentImmutable";
+import { ImageMediaImmutable } from "../schemas/types/Media/ImageMediaImmutable";
+import { BoardMediaImmutable } from "../schemas/types/Media/BoardMediaImmutable";
 
 
 type Key = string | number;
@@ -68,5 +72,13 @@ export const extractors: Record<string, Extractor> = {
     'CommentImmutable': {
         validator: CommentImmutableValidator,
         extract: keys<CommentImmutable>()
+    },
+    'ImageMediaImmutable': {
+        validator: ImageMediaImmutableValidator,
+        extract: keys<ImageMediaImmutable>()
+    },
+    'BoardMediaImmutable': {
+        validator: BoardMediaImmutableValidator,
+        extract: keys<BoardMediaImmutable>()
     }
 }

--- a/core/src/controllers/impl/CommentController.ts
+++ b/core/src/controllers/impl/CommentController.ts
@@ -1,0 +1,37 @@
+import { ClassOptions, ClassWrapper, Controller, Middleware, Patch, Post, Delete } from "@overnightjs/core";
+import { Request, Response } from "express";
+import AsyncHandler from "express-async-handler";
+import { RequiresAuth, Verified } from "../middlewares";
+import CommentService from "../../service/CommentService";
+
+@ClassWrapper(AsyncHandler)
+@ClassOptions({ mergeParams: true })
+@Controller("projects/:project/comments")
+export default class CommentController {
+    constructor(private readonly service: CommentService) {}
+
+    @Post()
+    @Middleware([ RequiresAuth, Verified("CommentImmutable") ])
+    public async createComment(req: Request, res: Response) {
+        const result = await this.service.createComment({
+            payload: req.verified,
+            resourceId: req.params.project,
+            claims: req.claims
+        })
+
+        res.status(200).json(result);
+    }
+
+    @Post(":comment")
+    @Middleware([ RequiresAuth, Verified("CommentImmutable") ])
+    public async replyComment(req: Request, res: Response) {
+        const result = await this.service.replyComment({
+            payload: req.verified,
+            outerResourceId: req.params.project,
+            innerResourceId: req.params.comment,
+            claims: req.claims
+        });
+
+        res.status(200).json(result);
+    }
+}

--- a/core/src/controllers/impl/MediaController.ts
+++ b/core/src/controllers/impl/MediaController.ts
@@ -2,53 +2,58 @@ import { ClassOptions, ClassWrapper, Controller, Middleware, Post } from "@overn
 import { Request, Response } from "express";
 import AsyncHandler from "express-async-handler";
 import { MediaRequestFactory } from "../mediaRequestFactory";
-import { RequiresContributor, RequiresSelf } from '../middlewares';
+import { RequiresContributor, RequiresSelf, Verified } from '../middlewares';
 
 @ClassWrapper(AsyncHandler)
 @ClassOptions({ mergeParams: true })
 @Controller("")
 export default class MediaController {
+
     constructor(private readonly requestFactory: MediaRequestFactory) {}
 
     @Post("users/:user/avatar")
-    @Middleware([ RequiresSelf('user') ])
+    @Middleware([ RequiresSelf('user'), Verified('ImageMediaImmutable') ])
     public async newAvatar(req: Request, res: Response) {
-        const result = this.requestFactory.knownFileRequest({
+        const result = await this.requestFactory.knownFileRequest({
             bucket: 'marqetplace-staging-photos',
-            key: `users/${req.params.user}/avatar`
+            key: `users/${req.params.user}/avatar`,
+            type: req.verified.type
         })
         
         res.status(200).json(result);
     }
 
     @Post("projects/:project/cover")
-    @Middleware([ RequiresContributor('project') ])
+    @Middleware([ RequiresContributor('project'), Verified('ImageMediaImmutable') ])
     public async newProjectCover(req: Request, res: Response) {
-        const result = this.requestFactory.knownFileRequest({
+        const result = await this.requestFactory.knownFileRequest({
             bucket: 'marqetplace-staging-photos',
-            key: `projects/${req.params.project}/cover`
+            key: `projects/${req.params.project}/cover`,
+            type: req.verified.type
         })
 
         res.status(200).json(result);
     }
 
     @Post("projects/:project/thumbnail")
-    @Middleware([ RequiresContributor('project') ])
+    @Middleware([ RequiresContributor('project'), Verified('ImageMediaImmutable') ])
     public async newProjectThumbnail(req: Request, res: Response) {
-        const result = this.requestFactory.knownFileRequest({
+        const result = await this.requestFactory.knownFileRequest({
             bucket: 'marqetplace-staging-photos',
-            key: `projects/${req.params.project}/thumbnail`
+            key: `projects/${req.params.project}/thumbnail`,
+            type: req.verified.type
         })
 
         res.status(200).json(result);
     }
 
     @Post("projects/:project/board/:entry")
-    @Middleware([ RequiresContributor('project') ])
+    @Middleware([ RequiresContributor('project'), Verified('BoardMediaImmutable') ])
     public async newProjectBoardMedia(req: Request, res: Response) {
-        const result = this.requestFactory.knownFileRequest({
+        const result = await this.requestFactory.knownFileRequest({
             bucket: 'marqetplace-staging-photos',
-            key: `projects/${req.params.project}/board/${req.params.entry}`
+            key: `projects/${req.params.project}/board/${req.params.entry}`,
+            type: req.verified.type
         })
 
         res.status(200).json(result);

--- a/core/src/controllers/mediaRequestFactory.ts
+++ b/core/src/controllers/mediaRequestFactory.ts
@@ -1,48 +1,42 @@
-import { uuidv4 } from 'uuid/v4';
+import { AllowedMedia } from '../schemas/types/Media/AllowedMedia';
 
 export namespace MediaRequestFactory {
-    export interface KnownDirectoryParams {
+
+    export interface Params {
         bucket: string,
-        directory: string // the path at which a new uuid will be generated
-    }
-    
-    export interface KnownFileParams {
-        bucket: string,
-        key: string // the full key to reach the s3 object, including any uuid needed
+        key: string,
+        type: AllowedMedia
     }
 }
+
 
 export class MediaRequestFactory {
 
     static TEN_MB = 10485760;
     static ONE_MINUTE = 60;
 
+    static CONTENT_TYPES: Record<AllowedMedia, string> = {
+        JPEG: 'image/jpeg',
+        PNG: 'image/png',
+        GIF: 'image/gif',
+        MP4: 'video/mp4'
+    }
+
     constructor(private readonly s3: AWS.S3) {}
 
-    private generateRequest(params: AWS.S3.PresignedPost.Params) {
-        const { url, fields } = this.s3.createPresignedPost(params);
+    private async generateRequest(params: AWS.S3.PresignedPost.Params) {
+        const { url, fields } = await this.s3.createPresignedPost(params);
         return { url, fields };
     }
 
-    public knownDirectoryRequest(params: MediaRequestFactory.KnownDirectoryParams) {
+    public async knownFileRequest(params: MediaRequestFactory.Params) {
         return this.generateRequest({
             Bucket: params.bucket,
             Expires: MediaRequestFactory.ONE_MINUTE,
             Fields: {
-                key: `${params.directory}/${new uuidv4()}`
-            },
-            Conditions: [
-                ['content-length-range', 0, MediaRequestFactory.TEN_MB]
-            ]
-        });
-    }
-
-    public knownFileRequest(params: MediaRequestFactory.KnownFileParams) {
-        return this.generateRequest({
-            Bucket: params.bucket,
-            Expires: MediaRequestFactory.ONE_MINUTE,
-            Fields: {
-                key: params.key
+                key: params.key,
+                acl: 'public-read',
+                'Content-Type': MediaRequestFactory.CONTENT_TYPES[params.type]
             },
             Conditions: [
                 ['content-length-range', 0, MediaRequestFactory.TEN_MB]

--- a/core/src/error/impl/AlreadyMemberError.ts
+++ b/core/src/error/impl/AlreadyMemberError.ts
@@ -1,0 +1,8 @@
+import { CustomError } from "ts-custom-error";
+
+export class AlreadyMemberError extends CustomError {
+
+    constructor(message: string) {
+        super(message);
+    }
+}

--- a/core/src/error/impl/NotAcceptingApplicationsError.ts
+++ b/core/src/error/impl/NotAcceptingApplicationsError.ts
@@ -1,0 +1,8 @@
+import { CustomError } from "ts-custom-error";
+
+export class NotAcceptingApplicationsError extends CustomError {
+
+    constructor(message: string) {
+        super(message);
+    }
+}

--- a/core/src/schemas/types/Comment/CommentImmutable.ts
+++ b/core/src/schemas/types/Comment/CommentImmutable.ts
@@ -1,4 +1,9 @@
-export interface Comment {
+export interface CommentImmutable {
+    /**
+     * An identifier for this comment
+     */
+    id: string;
+
     /**
      * The content of the comment
      * @minLength 1

--- a/core/src/schemas/types/Comment/CommentMaster.ts
+++ b/core/src/schemas/types/Comment/CommentMaster.ts
@@ -1,0 +1,35 @@
+import { CommentImmutable } from "./CommentImmutable";
+
+export interface CommentMaster extends CommentImmutable {
+    /**
+     * An identifier for this comment
+     */
+    id: string;
+
+    /**
+     * The project that the comment appears on
+     */
+    projectId: string;
+
+    /**
+     * The id of the comment that this replies to
+     */
+    parentId: string;
+
+    /**
+     * The id of the user that posted the comment
+     */
+    userId: string;
+
+    /**
+     * The content of the comment
+     * @minLength 1
+     * @maxLength 256
+     */
+    body: string;
+
+    /**
+     * When this comment was posted
+     */
+    createdAt: Date
+}

--- a/core/src/schemas/types/Media/AllowedMedia.ts
+++ b/core/src/schemas/types/Media/AllowedMedia.ts
@@ -1,0 +1,4 @@
+import { Image } from "./Image";
+import { Video } from "./Video";
+
+export type AllowedMedia = Image | Video;

--- a/core/src/schemas/types/Media/BoardMediaImmutable.ts
+++ b/core/src/schemas/types/Media/BoardMediaImmutable.ts
@@ -1,0 +1,5 @@
+import { AllowedMedia } from "./AllowedMedia";
+
+export interface BoardMediaImmutable {
+    type: AllowedMedia
+}

--- a/core/src/schemas/types/Media/Image.ts
+++ b/core/src/schemas/types/Media/Image.ts
@@ -1,0 +1,1 @@
+export type Image = 'JPEG' | 'PNG';

--- a/core/src/schemas/types/Media/ImageMediaImmutable.ts
+++ b/core/src/schemas/types/Media/ImageMediaImmutable.ts
@@ -1,0 +1,5 @@
+import { Image } from "./Image";
+
+export interface ImageMediaImmutable {
+    type: Image;
+}

--- a/core/src/schemas/types/Media/Video.ts
+++ b/core/src/schemas/types/Media/Video.ts
@@ -1,0 +1,1 @@
+export type Video = 'GIF' | 'MP4';

--- a/core/src/service/CommentService.ts
+++ b/core/src/service/CommentService.ts
@@ -1,0 +1,34 @@
+import * as Utils from './util';
+import { CommentImmutable } from '../schemas/types/Comment/CommentImmutable';
+import { CommentMaster } from '../schemas/types/Comment/CommentMaster';
+import { EventEmitter } from 'events';
+import { CreateCommentQuery } from '../access/queries/CreateCommentQuery';
+
+type CreateCommentParams = Utils.AuthenticatedSingleResourceServiceCall<CommentImmutable>;
+type ReplyCommentParams = Utils.AuthenticatedNestedResourceServiceCall<CommentImmutable>;
+
+export default class CommentService {
+
+    constructor(
+        private readonly emitter: EventEmitter,
+        private readonly createCommentQuery: CreateCommentQuery) {}
+
+    public async createComment(params: CreateCommentParams): Promise<CommentMaster> {
+        return this.createCommentQuery.execute({
+            id: params.payload.id,
+            projectId: params.resourceId,
+            userId: params.claims.username,
+            body: params.payload.body
+        })
+    }
+
+    public async replyComment(params: ReplyCommentParams): Promise<CommentMaster> {
+        return this.createCommentQuery.execute({
+            id: params.payload.id,
+            projectId: params.outerResourceId,
+            parentId: params.innerResourceId,
+            userId: params.claims.username,
+            body: params.payload.body
+        })
+    }
+}

--- a/core/src/service/util.ts
+++ b/core/src/service/util.ts
@@ -1,4 +1,5 @@
 import { Claims } from "../access/auth/verify";
+import { CustomError } from "ts-custom-error";
 
 export type UnauthenticatedServiceCall<T> = {
     payload: T;
@@ -57,3 +58,26 @@ export type UnauthenticatedNestedResourceServiceCall<T> = UnauthenticatedService
  *  }
  */
 export type AuthenticatedNestedResourceServiceCall<T> = AuthenticatedServiceCall<T> & NestedResourceID;
+
+/**
+ * Creates a series of nested try-catch blocks to eventually catch the result of some function
+ */
+export function translateErrors(errors: typeof CustomError[], klazz: typeof CustomError) {
+    return function(target, propertyKey: string, descriptor: PropertyDescriptor) {
+        const copy = descriptor.value;
+
+        descriptor.value = async function() {
+            try {
+                return await copy.apply(this, arguments);
+            } catch (e) {
+                for (const clazz of errors) {
+                    if (e instanceof clazz) {
+                        throw new klazz(e.message);
+                    }
+                }
+
+                throw e;
+            }
+        }
+    }
+}

--- a/core/test/integ/integ.test.ts
+++ b/core/test/integ/integ.test.ts
@@ -563,3 +563,80 @@ test('Can reply to a comment', async () => {
     expect(other.statusCode).toBe(200);
     expect(another.statusCode).toBe(200);
 })
+
+test('Apply to a project not accepting applications', async () => {
+    const project = uuid()
+    const application = uuid()
+
+    const create = await runner.runEvent({
+        httpMethod: "POST",
+        headers: {
+            "content-type": "application/json"
+        },
+        body: JSON.stringify({
+            id: project,
+            title: "Not accepting applications",
+            tagline: "Foo",
+            acceptingApplications: false
+        }),
+        path: "/projects",
+        queryStringParameters: {
+            id_token: tokenFactory.getToken(USER_ZERO)
+        }
+    });
+
+    const apply = await runner.runEvent({
+        httpMethod: "POST",
+        headers: {
+            "content-type": "application/json"
+        },
+        body: JSON.stringify({
+            id: application,
+        }),
+        path: `/projects/${project}/applications`,
+        queryStringParameters: {
+            id_token: tokenFactory.getToken(USER_ONE)
+        }
+    });
+
+    expect(create.statusCode).toBe(200);
+    expect(apply.statusCode).toBe(400);
+})
+
+test('Apply to a project the user is already a member of', async () => {
+    const project = uuid()
+    const application = uuid()
+
+    const create = await runner.runEvent({
+        httpMethod: "POST",
+        headers: {
+            "content-type": "application/json"
+        },
+        body: JSON.stringify({
+            id: project,
+            title: "Already a member",
+            tagline: "Foo"
+        }),
+        path: "/projects",
+        queryStringParameters: {
+            id_token: tokenFactory.getToken(USER_ZERO)
+        }
+    });
+
+    const apply = await runner.runEvent({
+        httpMethod: "POST",
+        headers: {
+            "content-type": "application/json"
+        },
+        body: JSON.stringify({
+            id: application,
+        }),
+        path: `/projects/${project}/applications`,
+        queryStringParameters: {
+            id_token: tokenFactory.getToken(USER_ZERO)
+        }
+    });
+
+    expect(create.statusCode).toBe(200);
+    expect(apply.statusCode).toBe(400);
+})

--- a/core/test/integ/integ.test.ts
+++ b/core/test/integ/integ.test.ts
@@ -468,3 +468,98 @@ test('Create a board entry on a project', async () => {
     expect(create.statusCode).toBe(200);
     expect(board.statusCode).toBe(200);
 })
+
+test('Can create comments on a project', async () => {
+    const project = uuid()
+    const comment = uuid()
+
+    const create = await runner.runEvent({
+        httpMethod: "POST",
+        headers: {
+            "content-type": "application/json"
+        },
+        body: JSON.stringify({
+            id: project,
+            title: "Create comment",
+            tagline: "Foo"
+        }),
+        path: "/projects",
+        queryStringParameters: {
+            id_token: tokenFactory.getToken(USER_ZERO)
+        }
+    });
+
+    const other = await runner.runEvent({
+        httpMethod: "POST",
+        headers: {
+            "content-type": "application/json"
+        },
+        body: JSON.stringify({
+            id: comment,
+            body: "Bar"
+        }),
+        path: `/projects/${project}/comments`,
+        queryStringParameters: {
+            id_token: tokenFactory.getToken(USER_ZERO)
+        }
+    })
+
+    expect(create.statusCode).toBe(200);
+    expect(other.statusCode).toBe(200);
+})
+
+test('Can reply to a comment', async () => {
+    const project = uuid()
+    const comment = uuid()
+    const reply = uuid()
+
+    const create = await runner.runEvent({
+        httpMethod: "POST",
+        headers: {
+            "content-type": "application/json"
+        },
+        body: JSON.stringify({
+            id: project,
+            title: "Create comment",
+            tagline: "Foo"
+        }),
+        path: "/projects",
+        queryStringParameters: {
+            id_token: tokenFactory.getToken(USER_ZERO)
+        }
+    });
+
+    const other = await runner.runEvent({
+        httpMethod: "POST",
+        headers: {
+            "content-type": "application/json"
+        },
+        body: JSON.stringify({
+            id: comment,
+            body: "Bar"
+        }),
+        path: `/projects/${project}/comments`,
+        queryStringParameters: {
+            id_token: tokenFactory.getToken(USER_ZERO)
+        }
+    })
+
+    const another = await runner.runEvent({
+        httpMethod: "POST",
+        headers: {
+            "content-type": "application/json"
+        },
+        body: JSON.stringify({
+            id: reply,
+            body: "Bar"
+        }),
+        path: `/projects/${project}/comments/${comment}`,
+        queryStringParameters: {
+            id_token: tokenFactory.getToken(USER_ZERO)
+        }
+    })
+
+    expect(create.statusCode).toBe(200);
+    expect(other.statusCode).toBe(200);
+    expect(another.statusCode).toBe(200);
+})

--- a/core/test/integ/integ.test.ts
+++ b/core/test/integ/integ.test.ts
@@ -174,6 +174,9 @@ test('Can access media endpoints for self', async () => {
         headers: {
             "content-type": "application/json"
         },
+        body: JSON.stringify({
+            type: "JPEG"
+        }),
         path: `/users/${USER_ZERO}/avatar`,
         queryStringParameters: {
             id_token: tokenFactory.getToken(USER_ZERO)
@@ -639,4 +642,26 @@ test('Apply to a project the user is already a member of', async () => {
 
     expect(create.statusCode).toBe(200);
     expect(apply.statusCode).toBe(400);
+})
+
+
+test('Content types for media uploads are respected', async () => {
+    const upload = await runner.runEvent({
+        httpMethod: "POST",
+        headers: {
+            "content-type": "application/json"
+        },
+        body: JSON.stringify({
+            type: 'JPEG'
+        }),
+        path: `/users/${USER_ZERO}/avatar`,
+        queryStringParameters: {
+            id_token: tokenFactory.getToken(USER_ZERO)
+        }
+    })
+
+    const body = JSON.parse(upload.body);
+
+    expect(upload.statusCode).toBe(200);
+    expect(body.fields['Content-Type']).toBe('image/jpeg');
 })


### PR DESCRIPTION
We're adding in a basic version of the comment system, as well as some better handling of content types with media uploads.

Now, when a user wants to upload media to the server, the client will need to specify what type of media is being uploaded.  This allows the server to establish some metadata about the content, which helps establish how to view the media when it is retrieved.